### PR TITLE
Change how get the google credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ $ export TWITTER_CONSUMER_KEY=<APP_CONSUMER_KEY>
 $ export TWITTER_CONSUMER_SECRET=<APP_CONSUMER_SECRET>
 ```
 - Go to ```https://console.developers.google.com/```, create a project
-and then create a service account credential.
+and then create a service account credential. This action will generate a file json.
 
-Export them as environment variables like:
+Export it as environment variable like:
 
 ```
-export GSPREAD_CLIENT_EMAIL=<GOOGLE_CLIENT_EMAIL>
-export GSPREAD_PRIVATE_KEY_ID=<GOOGLE_PRIVATE_KEY_ID>
-export GSPREAD_PRIVATE_KEY=<GOOGLE_PRIVATE_KEY>
+export GSPREAD_JSON_FILE=<FILE_NAME>
 ```
+
+**The file should be on the root of the project.**
 
 - Create a Google Spreadsheet and share it with the GOOGLE_CLIENT_EMAIL
 generated in the step above.

--- a/export_google_sheet.py
+++ b/export_google_sheet.py
@@ -46,15 +46,11 @@ def _export_to_google(wks, blips_to_export):
 
 def export_all(tweets):
     scope = ['https://spreadsheets.google.com/feeds']
-    client_email = os.getenv('GSPREAD_CLIENT_EMAIL')
-#    private_key = os.getenv('GSPREAD_PRIVATE_KEY').encode()
-#    private_key_id = os.getenv('GSPREAD_PRIVATE_KEY_ID')
-#    signer = crypt.Signer.from_string(private_key)
+    
     sheet_name = os.getenv('GSPREAD_SHEET_NAME')
     worksheet_previous_radar_name = os.getenv('GSPREAD_PREVIOUS_RADAR_NAME')
 
-#    credentials = ServiceAccountCredentials(service_account_email=client_email, signer=signer, private_key_id=private_key_id, scopes=scope)
-    credentials = ServiceAccountCredentials.from_json_keyfile_name('../tweet-c87efffffce1.json', scope)
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(os.getenv('GSPREAD_JSON_FILE'), scope)
     gc = gspread.authorize(credentials)
 
     sht = gc.open(sheet_name)

--- a/export_google_sheet.py
+++ b/export_google_sheet.py
@@ -47,13 +47,14 @@ def _export_to_google(wks, blips_to_export):
 def export_all(tweets):
     scope = ['https://spreadsheets.google.com/feeds']
     client_email = os.getenv('GSPREAD_CLIENT_EMAIL')
-    private_key = os.getenv('GSPREAD_PRIVATE_KEY').encode()
-    private_key_id = os.getenv('GSPREAD_PRIVATE_KEY_ID')
-    signer = crypt.Signer.from_string(private_key)
+#    private_key = os.getenv('GSPREAD_PRIVATE_KEY').encode()
+#    private_key_id = os.getenv('GSPREAD_PRIVATE_KEY_ID')
+#    signer = crypt.Signer.from_string(private_key)
     sheet_name = os.getenv('GSPREAD_SHEET_NAME')
     worksheet_previous_radar_name = os.getenv('GSPREAD_PREVIOUS_RADAR_NAME')
 
-    credentials = ServiceAccountCredentials(service_account_email=client_email, signer=signer, private_key_id=private_key_id, scopes=scope)
+#    credentials = ServiceAccountCredentials(service_account_email=client_email, signer=signer, private_key_id=private_key_id, scopes=scope)
+    credentials = ServiceAccountCredentials.from_json_keyfile_name('../tweet-c87efffffce1.json', scope)
     gc = gspread.authorize(credentials)
 
     sht = gc.open(sheet_name)


### PR DESCRIPTION
Hi Maite,

Issue:
`crypt.Signer.from_string` was raising an error "ValueError: No key could be detected." , even with the env variable GSPREAD_PRIVATE_KEY setted (I printed the value got in my variable).
After some researches, apparently my private key is correct but for some reason the Signer could not read it.

I solved this using `ServiceAccountCredentials.from_json_keyfile_name` which read direct from the json file all the needed credentials.

It's a suggestion to use. 
